### PR TITLE
Dev 5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-          outputs: |
+          # outputs: |
               # type=image,name=target,annotation-index.org.opencontainers.image.description=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.description'] }},annotation-index.org.opencontainers.image.source=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.source'] }},annotation-index.org.opencontainers.image.licenses=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.licenses'] }}
 
       - name: Docker Hub Description

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dist": "mkdir -p dist && cp app.js dist",
     "clean": "rm -rf dist",
-    "start": "node app.js"
+    "start": "node app.js",
+    "preversion": "git fetch --tags",
+    "postversion": "git push --follow-tags"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Keep git tags in sync with GitHub for an NPM project.
- Disable outputs in "Build and push" step.